### PR TITLE
Update configure-phpstorm.md

### DIFF
--- a/_articles/develop-on-site-stacker/configure-phpstorm.md
+++ b/_articles/develop-on-site-stacker/configure-phpstorm.md
@@ -21,8 +21,8 @@ Open PhpStorm settings window (File > Settings or Ctrl+Alt+S)
 This will make PhpStorm know that the webroot folder is holding all the possible assets and will offer paths auto completion.
 </note>
 
-#### Marking `lib` and `app` duplicated PHP files as Plain text  
-Each file located in `App/Lib` has a corresponding file in `lib/Cake`. In order to have correct auto completion when using CakePHP methods in your code make sure that each file found in `App/Lib` has the corresponding file in `Lib/Cake` marked as plain text. You can do this by right clicking the file and choosing the `Mark as plain text` option.
+#### Marking `lib/Cake` and `App/Lib` duplicated PHP files as Plain text  
+Each file located in `App/Lib` has a corresponding file in `lib/Cake`. In order to have correct auto completion when using CakePHP methods in your code make sure that each file found in `App/Lib` has the corresponding file in `lib/Cake` and mark all files in `lib/Cake` as plain text. You can do this by right clicking the file and choosing the `Mark as plain text` option.
 
 #### Marking `webroot/lib` files as Plain text
 PhpStorm is building the JS auto complete options by reading every JS file found in the `Resource` directory which is the `webroot` folder. Because SiteStacker has a lot of JS libraries in the `webroot/lib` folder, PhpStorm will sometime become unresponsive and offer very slow JS auto completion. To fix this you can `Mark as plain text` every JS and CSS file found in `webroot/lib`. This can take some time but it will dramatically improve PhpStorm functionality and responsiveness.
@@ -34,5 +34,5 @@ We have a list of required and optional plugins that you need to install. Here i
     - When you open some files you might get a notice from PhpStorm telling you that the `.editorconfig` file is overwriting some formatting settings. If you get this notice click `Dismiss`.
     - Some existing files might not match the `.editorconfig` settings. If you work on a file like this, before you start making your changes, click on Code > Reformat code from the top menu and immediately commit this change.
 2. **MultiMarkdown** (OPTIONAL) - Enable support for Markdown `.md` files.
-3. **.gitignore** (OPTIONAL) - Enable support for `.gitignore` files.
+3. **.ignore** (OPTIONAL) - Enable support for `.gitignore` files.
 4. **Database Tools and SQL** (OPTIONAL) - Enable MySQL and MSSQL support and syntax highlighting.

--- a/_articles/develop-on-site-stacker/configure-phpstorm.md
+++ b/_articles/develop-on-site-stacker/configure-phpstorm.md
@@ -22,7 +22,7 @@ This will make PhpStorm know that the webroot folder is holding all the possible
 </note>
 
 #### Marking `lib/Cake` and `App/Lib` duplicated PHP files as Plain text  
-Each file located in `App/Lib` has a corresponding file in `lib/Cake`. In order to have correct auto completion when using CakePHP methods in your code make sure that each file found in `App/Lib` has the corresponding file in `lib/Cake` and mark all files in `lib/Cake` as plain text. You can do this by right clicking the file and choosing the `Mark as plain text` option.
+Each file located in `App/Lib` has a corresponding file in `lib/Cake`. In order to have correct auto completion when using CakePHP methods in your code make sure that each file found in `App/Lib` has the corresponding file in `lib/Cake` and mark all duplicated files in `lib/Cake` as plain text. You can do this by right clicking the file and choosing the `Mark as plain text` option.
 
 #### Marking `webroot/lib` files as Plain text
 PhpStorm is building the JS auto complete options by reading every JS file found in the `Resource` directory which is the `webroot` folder. Because SiteStacker has a lot of JS libraries in the `webroot/lib` folder, PhpStorm will sometime become unresponsive and offer very slow JS auto completion. To fix this you can `Mark as plain text` every JS and CSS file found in `webroot/lib`. This can take some time but it will dramatically improve PhpStorm functionality and responsiveness.


### PR DESCRIPTION
Shouldn't that second "Lib/Cake" be "lib/Cake" under "Marking lib and app duplicated PHP files as Plain text"? And it's not so clear which one should be marked as plain text, but I guess "lib/Cake".

Also I think that plugin is just .ignore instead of .gitignore.